### PR TITLE
メッセージを受信し、ページに反映できるよう設定

### DIFF
--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,6 +1,7 @@
 class RoomChannel < ApplicationCable::Channel
   def subscribed
-    # stream_from "some_channel"
+    # 配信する部屋名を決定
+    stream_from "room_channel"
   end
 
   def unsubscribed

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,8 @@
 class MessagesController < ApplicationController
   def create
     @message = current_user.messages.create!(message_params)
+    # 投稿されたメッセージをチャット参加者に配信
+    ActionCable.server.broadcast "room_channel", message: @message.template
   end
 
   private

--- a/app/javascript/channels/room_channel.js
+++ b/app/javascript/channels/room_channel.js
@@ -1,15 +1,23 @@
-import consumer from "./consumer"
+import consumer from "./consumer";
 
-consumer.subscriptions.create("RoomChannel", {
-  connected() {
-    // Called when the subscription is ready for use on the server
-  },
+// turbolinks の読み込みが終わった後にidを取得しないと，エラーが出ます。
+document.addEventListener("turbolinks:load", () => {
+  // js.erb 内で使用できるように変数を定義しておく
+  window.messageContainer = document.getElementById("message-container");
 
-  disconnected() {
-    // Called when the subscription has been terminated by the server
-  },
-
-  received(data) {
-    // Called when there's incoming data on the websocket for this channel
+  // 以下のプログラムが他のページで動作しないようにしておく
+  if (messageContainer === null) {
+    return;
   }
+
+  consumer.subscriptions.create("RoomChannel", {
+    connected() {},
+
+    disconnected() {},
+
+    received(data) {
+      // サーバー側から受け取ったHTMLを一番最後に加える
+      messageContainer.insertAdjacentHTML("beforeend", data["message"]);
+    },
+  });
 });

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,4 +3,9 @@ class Message < ApplicationRecord
 
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 500 }
+
+  # 投稿されたメッセージをメッセージ用の部分テンプレートでHTMLに変換
+  def template
+    ApplicationController.renderer.render partial: "messages/message", locals: { message: self }
+  end
 end


### PR DESCRIPTION
## 内容

- 配信する部屋名を決定
- 投稿されたメッセージをチャット参加者に配信できるよう設定
- 投稿されたメッセージをメッセージ用の部分テンプレートでHTMLに変換
- JSでサーバー側から受け取ったHTMLを一番最後に加えるよう設定